### PR TITLE
ported the examples to local-by-default

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "postcss": "^4.1.11",
     "postcss-modules-extract-imports": "0.0.1",
-    "postcss-modules-local-by-default": "0.0.6",
+    "postcss-modules-local-by-default": "0.0.7",
     "postcss-modules-scope": "0.0.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export default {
 
   // The default set of plugins
   plugins: [
-    //localByDefault,
+    localByDefault,
     extractImports,
     scope
   ],

--- a/test/test-cases/simple-export/expected.css
+++ b/test/test-cases/simple-export/expected.css
@@ -1,3 +1,4 @@
-.__globalName {
+
+._simple_export_source__localName {
   color: red;
 }

--- a/test/test-cases/simple-export/expected.json
+++ b/test/test-cases/simple-export/expected.json
@@ -1,3 +1,3 @@
 {
-  "localName": "__globalName __otherName"
+  "localName": "_simple_export_source__localName"
 }

--- a/test/test-cases/simple-export/source.css
+++ b/test/test-cases/simple-export/source.css
@@ -1,7 +1,3 @@
-:export {
-  localName: __globalName __otherName;
-}
-
-.__globalName {
+.localName {
   color: red;
 }

--- a/test/test-cases/single-import-export/colors.css
+++ b/test/test-cases/single-import-export/colors.css
@@ -1,7 +1,3 @@
-:export {
-  blackShadow: __global_blackShadow;
-}
-
-.__global_blackShadow {
+.blackShadow {
   box-shadow: 0 0 10px -2px black;
 }

--- a/test/test-cases/single-import-export/expected.css
+++ b/test/test-cases/single-import-export/expected.css
@@ -1,6 +1,8 @@
-.__global_blackShadow {
+
+._single_import_export_colors__blackShadow {
   box-shadow: 0 0 10px -2px black;
 }
-.__globalName {
+
+._single_import_export_source__localName {
   color: red;
 }

--- a/test/test-cases/single-import-export/expected.json
+++ b/test/test-cases/single-import-export/expected.json
@@ -1,3 +1,3 @@
 {
-  "localName": "__globalName __global_blackShadow"
+  "localName": "_single_import_export_source__localName _single_import_export_colors__blackShadow"
 }

--- a/test/test-cases/single-import-export/source.css
+++ b/test/test-cases/single-import-export/source.css
@@ -1,11 +1,4 @@
-:import("./colors.css") {
-  blackShadow: __tmp_blackShadow;
-}
-
-:export {
-  localName: __globalName __tmp_blackShadow;
-}
-
-.__globalName {
+.localName {
+  extends: blackShadow from "./colors.css";
   color: red;
 }


### PR DESCRIPTION
Might be worth breaking out the interchange-format loader from this package, and putting these tests back. But these work better as integration tests.
