### PR TITLE
Added a failing test case (pseudo selector)

### DIFF
--- a/test/test-cases/simple-export/expected.css
+++ b/test/test-cases/simple-export/expected.css
@@ -2,3 +2,7 @@
 ._simple_export_source__localName {
   color: red;
 }
+
+._simple_export_source__localName:hover {
+  color: blue;
+}

--- a/test/test-cases/simple-export/source.css
+++ b/test/test-cases/simple-export/source.css
@@ -1,3 +1,7 @@
 .localName {
   color: red;
 }
+
+.localName:hover {
+  color: blue;
+}


### PR DESCRIPTION
Selector `.localName:hover` is output as `:local(.localName):hover` instead of `.[prefix]__localName:hover`

I'll start working on getting this to pass, but let me know if you have any thoughts in the meantime.
