### PR TITLE
Fixed relative paths

### DIFF
--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -31,8 +31,9 @@ export default class FileSystemLoader {
     let newPath = _newPath.replace( /^["']|["']$/g, "" ),
       trace = _trace || String.fromCharCode( this.importNr++ )
     return new Promise( ( resolve, reject ) => {
-      let rootRelativePath = path.resolve( path.dirname( relativeTo ), newPath ),
-        fileRelativePath = this.root + rootRelativePath
+      let relativeDir = path.dirname( relativeTo ),
+        rootRelativePath = path.resolve( relativeDir, newPath ),
+        fileRelativePath = path.resolve( path.join( this.root, relativeDir ), newPath )
 
       fs.readFile( fileRelativePath, "utf-8", ( err, source ) => {
         if ( err ) reject( err )


### PR DESCRIPTION
In the https://github.com/css-modules/browserify-demo repo, all the `composes` are commented out, for example:

[StyleVariantA.css](https://github.com/css-modules/browserify-demo/blob/e58aae76168cb5864ea0759ebdd4178bbb27e91b/src/components/3-ClassComposition/StyleVariantA/StyleVariantA.css)

``` css
.root {
  /*composes: box from "../../../shared/styles/layout.css";*/
  border-color: red;
}

.text {
  /*composes: heading from "../../../shared/styles/typography.css";*/
  color: red;
}
```

Uncommenting these lines results in `ENOENT` on build.

This PR fixes the resolution of these relative paths if we uncomment them.
