### PR TITLE
Failing test for global selectors

### DIFF
--- a/test/test-cases/global-export/expected.css
+++ b/test/test-cases/global-export/expected.css
@@ -1,0 +1,8 @@
+
+.globalName {
+  color: red;
+}
+
+._global_export_source__localName p {
+  color: green;
+}

--- a/test/test-cases/global-export/expected.json
+++ b/test/test-cases/global-export/expected.json
@@ -1,0 +1,3 @@
+{
+  "localName": "_global_export_source__localName"
+}

--- a/test/test-cases/global-export/source.css
+++ b/test/test-cases/global-export/source.css
@@ -1,0 +1,7 @@
+:global .globalName {
+  color: red;
+}
+
+.localName :global p {
+  color: green;
+}


### PR DESCRIPTION
Selectors like `:global .globalName` are working, but not `.localName :global p`.
