### PR TITLE
resolve paths to node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-node_modules
+node_modules/*
+!node_modules/cool-styles
 lib

--- a/node_modules/cool-styles/foo.css
+++ b/node_modules/cool-styles/foo.css
@@ -1,0 +1,3 @@
+.example {
+  color: #F00;
+}

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -36,6 +36,14 @@ export default class FileSystemLoader {
         rootRelativePath = path.resolve( relativeDir, newPath ),
         fileRelativePath = path.resolve( path.join( this.root, relativeDir ), newPath )
 
+      // if the path is not relative or absolute, try to resolve it in node_modules
+      if (newPath[0] !== '.' && newPath[0] !== '/') {
+        try {
+          fileRelativePath = require.resolve(newPath);
+        }
+        catch (e) {}
+      }
+
       const tokens = this.tokensByFile[fileRelativePath]
       if (tokens) { return resolve(tokens) }
 

--- a/test/test-cases/compose-node-module/expected.css
+++ b/test/test-cases/compose-node-module/expected.css
@@ -1,0 +1,5 @@
+._compose_node_module_cool_styles_foo__example {
+  color: #F00;
+}
+._compose_node_module_source__foo {
+}

--- a/test/test-cases/compose-node-module/expected.json
+++ b/test/test-cases/compose-node-module/expected.json
@@ -1,0 +1,3 @@
+{
+  "foo": "_compose_node_module_source__foo _compose_node_module_cool_styles_foo__example"
+}

--- a/test/test-cases/compose-node-module/source.css
+++ b/test/test-cases/compose-node-module/source.css
@@ -1,0 +1,3 @@
+.foo {
+  composes: example from "cool-styles/foo.css";
+}


### PR DESCRIPTION
This update adds a `require.resolve` (if the path is not relative or absolute) so that we can compose from 3rd-party modules. 

Once this is merged and a new version published I'll be able to get https://github.com/css-modules/css-modulesify/pull/25 passing too.
