### PR TITLE
Media queries support & 1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "dependencies": {
     "postcss": "^4.1.11",
     "postcss-custom-media": "^4.1.0",
-    "postcss-modules-extract-imports": "^0.0.5",
+    "postcss-modules-extract-imports": "^1.0.0-beta1",
     "postcss-modules-local-by-default": "^0.0.9",
-    "postcss-modules-scope": "^0.0.8"
+    "postcss-modules-scope": "^1.0.0-beta1"
   },
   "devDependencies": {
     "babel": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-modules-loader-core",
-  "version": "0.0.12",
+  "version": "1.0.0-beta1",
   "description": "A loader-agnostic CSS Modules implementation, based on PostCSS",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "postcss": "^4.1.11",
+    "postcss-custom-media": "^4.1.0",
     "postcss-modules-extract-imports": "^0.0.5",
     "postcss-modules-local-by-default": "^0.0.9",
     "postcss-modules-scope": "^0.0.8"

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -20,11 +20,11 @@ const traceKeySorter = ( a, b ) => {
 };
 
 export default class FileSystemLoader {
-  constructor( root, plugins ) {
+  constructor( root, plugins, postLinkers ) {
     this.root = root
     this.sources = {}
     this.importNr = 0
-    this.core = new Core(plugins)
+    this.core = new Core( plugins, postLinkers )
     this.tokensByFile = {};
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,18 +2,23 @@ import postcss from 'postcss'
 import localByDefault from 'postcss-modules-local-by-default'
 import extractImports from 'postcss-modules-extract-imports'
 import scope from 'postcss-modules-scope'
+import customMedia from 'postcss-custom-media'
 
 import Parser from './parser'
 
 export default class Core {
-  constructor( plugins ) {
+  constructor( plugins, postLinkers ) {
     this.plugins = plugins || Core.defaultPlugins
+    this.postLinkers = postLinkers || Core.defaultPostLinkers
   }
 
   load( sourceString, sourcePath, trace, pathFetcher ) {
-    let parser = new Parser( pathFetcher, trace )
+    let parser = new Parser( pathFetcher, trace ),
+      pluginChain = this.plugins
+        .concat( [parser.plugin] )
+        .concat( this.postLinkers );
 
-    return postcss( this.plugins.concat( [parser.plugin] ) )
+    return postcss( pluginChain )
       .process( sourceString, { from: "/" + sourcePath } )
       .then( result => {
         return { injectableSource: result.css, exportTokens: parser.exportTokens }
@@ -21,8 +26,10 @@ export default class Core {
   }
 }
 
-// These three plugins are aliased under this package for simplicity.
+// These four plugins are aliased under this package for simplicity.
 Core.localByDefault = localByDefault
 Core.extractImports = extractImports
 Core.scope = scope
+Core.customMedia = customMedia
 Core.defaultPlugins = [localByDefault, extractImports, scope]
+Core.defaultPostLinkers = [customMedia]

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ export default class Core {
   }
 }
 
-
 // These three plugins are aliased under this package for simplicity.
 Core.localByDefault = localByDefault
 Core.extractImports = extractImports

--- a/src/parser.js
+++ b/src/parser.js
@@ -53,7 +53,7 @@ export default class Parser {
         Object.keys(this.translations).forEach( translation => {
           decl.value = decl.value.replace(translation, this.translations[translation])
         } )
-        this.exportTokens[decl.prop] = decl.value
+        this.exportTokens[decl.prop] = decl.value.replace(/^['"]|['"]$/g, '')
       }
     } )
     exportNode.removeSelf()
@@ -65,7 +65,12 @@ export default class Parser {
     return this.pathFetcher( file, relativeTo, depTrace ).then( exports => {
       importNode.each( decl => {
         if ( decl.type == 'decl' ) {
-          this.translations[decl.prop] = exports[decl.value].replace(/^['"]|['"]$/g,'')
+          let translation = exports[decl.value]
+          if ( translation ) {
+            this.translations[decl.prop] = translation.replace(/^['"]|['"]$/g, '')
+          } else {
+            console.warn( `Missing ${decl.value} for ${decl.prop}` )
+          }
         }
       } )
       importNode.removeSelf()

--- a/test/cssi/media-queries/breakpoints.css
+++ b/test/cssi/media-queries/breakpoints.css
@@ -1,4 +1,4 @@
-:exports {
+:export {
   --small: "(max-width: 30em)";
   --medium: "(max-width: 60em)";
   --large: "(max-width: 90em)";

--- a/test/cssi/media-queries/breakpoints.css
+++ b/test/cssi/media-queries/breakpoints.css
@@ -1,9 +1,9 @@
 :exports {
-  --small: --x__breakpoints__small;
-  --medium: --x__breakpoints__medium;
-  --large: --x__breakpoints__large;
+  --small: "(max-width: 30em)";
+  --medium: "(max-width: 60em)";
+  --large: "(max-width: 90em)";
 }
 
-@custom-media --x__breakpoints__small (max-width: 30em);
-@custom-media --x__breakpoints__medium (max-width: 60em);
-@custom-media --x__breakpoints__large (max-width: 90em);
+@custom-media --small (max-width: 30em);
+@custom-media --medium (max-width: 60em);
+@custom-media --large (max-width: 90em);

--- a/test/cssi/media-queries/breakpoints.css
+++ b/test/cssi/media-queries/breakpoints.css
@@ -1,0 +1,9 @@
+:exports {
+  --small: --x__breakpoints__small;
+  --medium: --x__breakpoints__medium;
+  --large: --x__breakpoints__large;
+}
+
+@custom-media --x__breakpoints__small (max-width: 30em);
+@custom-media --x__breakpoints__medium (max-width: 60em);
+@custom-media --x__breakpoints__large (max-width: 90em);

--- a/test/cssi/media-queries/expected.css
+++ b/test/cssi/media-queries/expected.css
@@ -1,6 +1,9 @@
 @custom-media --small (max-width: 30em);
 @custom-media --medium (max-width: 60em);
 @custom-media --large (max-width: 90em);
+@custom-media --small (max-width: 30em);
+@custom-media --medium (max-width: 60em);
+@custom-media --large (max-width: 90em);
 
 .exported-red {
   color: red;

--- a/test/cssi/media-queries/expected.css
+++ b/test/cssi/media-queries/expected.css
@@ -1,25 +1,25 @@
-@custom-media --x__source__small (max-width: 30em);
-@custom-media --x__source__medium (max-width: 60em);
-@custom-media --x__source__large (max-width: 90em);
+@custom-media --small (max-width: 30em);
+@custom-media --medium (max-width: 60em);
+@custom-media --large (max-width: 90em);
 
-._media-queries_source__red {
+.exported-red {
   color: red;
 }
 
-@media (max-width: 30em) {
-  ._media-queries_source__red {
+@media (--small) {
+  .exported-red {
     color: maroon;
   }
 }
 
-@media (max-width: 60em) {
-  ._media-queries_source__red {
+@media (--medium) {
+  .exported-red {
     color: darkmagenta;
   }
 }
 
-@media (max-width: 90em) {
-  ._media-queries_source__red {
+@media (--large) {
+  .exported-red {
     color: fuchsia;
   }
 }

--- a/test/cssi/media-queries/expected.css
+++ b/test/cssi/media-queries/expected.css
@@ -1,0 +1,25 @@
+@custom-media --x__source__small (max-width: 30em);
+@custom-media --x__source__medium (max-width: 60em);
+@custom-media --x__source__large (max-width: 90em);
+
+._media-queries_source__red {
+  color: red;
+}
+
+@media (max-width: 30em) {
+  ._media-queries_source__red {
+    color: maroon;
+  }
+}
+
+@media (max-width: 60em) {
+  ._media-queries_source__red {
+    color: darkmagenta;
+  }
+}
+
+@media (max-width: 90em) {
+  ._media-queries_source__red {
+    color: fuchsia;
+  }
+}

--- a/test/cssi/media-queries/expected.json
+++ b/test/cssi/media-queries/expected.json
@@ -1,0 +1,5 @@
+{
+  "--small": "--x__source__small",
+  "--medium": "--x__source__medium",
+  "--large": "--x__source__large"
+}

--- a/test/cssi/media-queries/expected.json
+++ b/test/cssi/media-queries/expected.json
@@ -1,5 +1,6 @@
 {
-  "--small": "--x__source__small",
-  "--medium": "--x__source__medium",
-  "--large": "--x__source__large"
+  "--small": "(max-width: 30em)",
+  "--medium": "(max-width: 60em)",
+  "--large": "(max-width: 90em)",
+  "red": "exported-red"
 }

--- a/test/cssi/media-queries/source.css
+++ b/test/cssi/media-queries/source.css
@@ -1,0 +1,37 @@
+:imports("./breakpoints.css") {
+  --i__breakpoints__small: --small;
+  --i__breakpoints__medium: --medium;
+  --i__breakpoints__large: --large;
+}
+
+:exports {
+  --small: --x__source__small;
+  --medium: --x__source__medium;
+  --large: --x__source__large;
+}
+
+@custom-media --x__source__small --i__breakpoints__small;
+@custom-media --x__source__medium --i__breakpoints__medium;
+@custom-media --x__source__large --i__breakpoints__large;
+
+.red {
+  color: red;
+}
+
+@media (--x__source__small) {
+  .red {
+    color: maroon;
+  }
+}
+
+@media (--x__source__medium) {
+  .red {
+    color: darkmagenta;
+  }
+}
+
+@media (--x__source__large) {
+  .red {
+    color: fuchsia;
+  }
+}

--- a/test/cssi/media-queries/source.css
+++ b/test/cssi/media-queries/source.css
@@ -1,37 +1,38 @@
-:imports("./breakpoints.css") {
-  --i__breakpoints__small: --small;
-  --i__breakpoints__medium: --medium;
-  --i__breakpoints__large: --large;
+:import("./breakpoints.css") {
+  i__breakpoints__small: --small;
+  i__breakpoints__medium: --medium;
+  i__breakpoints__large: --large;
 }
 
-:exports {
-  --small: --x__source__small;
-  --medium: --x__source__medium;
-  --large: --x__source__large;
+:export {
+  --small: i__breakpoints__small;
+  --medium: i__breakpoints__medium;
+  --large: i__breakpoints__large;
+  red: exported-red;
 }
 
-@custom-media --x__source__small --i__breakpoints__small;
-@custom-media --x__source__medium --i__breakpoints__medium;
-@custom-media --x__source__large --i__breakpoints__large;
+@custom-media --small i__breakpoints__small;
+@custom-media --medium i__breakpoints__medium;
+@custom-media --large i__breakpoints__large;
 
-.red {
+.exported-red {
   color: red;
 }
 
-@media (--x__source__small) {
-  .red {
+@media (--small) {
+  .exported-red {
     color: maroon;
   }
 }
 
-@media (--x__source__medium) {
-  .red {
+@media (--medium) {
+  .exported-red {
     color: darkmagenta;
   }
 }
 
-@media (--x__source__large) {
-  .red {
+@media (--large) {
+  .exported-red {
     color: fuchsia;
   }
 }

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -21,7 +21,7 @@ Object.keys( pipelines ).forEach( dirname => {
       if ( fs.existsSync( path.join( testDir, testCase, "source.css" ) ) ) {
         it( "should " + testCase.replace( /-/g, " " ), done => {
           let expected = normalize( fs.readFileSync( path.join( testDir, testCase, "expected.css" ), "utf-8" ) )
-          let loader = new FileSystemLoader( testDir, pipelines[dirname] )
+          let loader = new FileSystemLoader( testDir, pipelines[dirname], pipelines[dirname] )
           let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, "expected.json" ), "utf-8" ) )
           loader.fetch( `${testCase}/source.css`, "/" ).then( tokens => {
             assert.equal( loader.finalSource, expected )

--- a/test/test-cases/media-queries/breakpoints.css
+++ b/test/test-cases/media-queries/breakpoints.css
@@ -1,3 +1,2 @@
 @custom-media --small (max-width: 30em);
 @custom-media --medium (max-width: 60em);
-@custom-media --large (max-width: 90em);

--- a/test/test-cases/media-queries/breakpoints.css
+++ b/test/test-cases/media-queries/breakpoints.css
@@ -1,0 +1,3 @@
+@custom-media --small (max-width: 30em);
+@custom-media --medium (max-width: 60em);
+@custom-media --large (max-width: 90em);

--- a/test/test-cases/media-queries/expected.css
+++ b/test/test-cases/media-queries/expected.css
@@ -1,21 +1,27 @@
-._media-queries_source__red {
+@custom-media --small (max-width: 30em);
+@custom-media --medium (max-width: 60em);
+@custom-media --small (max-width: 30em);
+@custom-media --medium (max-width: 60em);
+@custom-media --large (max-width: 90em);
+
+._media_queries_source__red {
   color: red;
 }
 
-@media (max-width: 30em) {
-  ._media-queries_source__red {
+@media (--small) {
+  ._media_queries_source__red {
     color: maroon;
   }
 }
 
-@media (max-width: 60em) {
-  ._media-queries_source__red {
+@media (--medium) {
+  ._media_queries_source__red {
     color: darkmagenta;
   }
 }
 
-@media (max-width: 90em) {
-  ._media-queries_source__red {
+@media (--large) {
+  ._media_queries_source__red {
     color: fuchsia;
   }
 }

--- a/test/test-cases/media-queries/expected.css
+++ b/test/test-cases/media-queries/expected.css
@@ -1,0 +1,21 @@
+._media-queries_source__red {
+  color: red;
+}
+
+@media (max-width: 30em) {
+  ._media-queries_source__red {
+    color: maroon;
+  }
+}
+
+@media (max-width: 60em) {
+  ._media-queries_source__red {
+    color: darkmagenta;
+  }
+}
+
+@media (max-width: 90em) {
+  ._media-queries_source__red {
+    color: fuchsia;
+  }
+}

--- a/test/test-cases/media-queries/expected.css
+++ b/test/test-cases/media-queries/expected.css
@@ -1,26 +1,21 @@
-@custom-media --small (max-width: 30em);
-@custom-media --medium (max-width: 60em);
-@custom-media --small (max-width: 30em);
-@custom-media --medium (max-width: 60em);
-@custom-media --large (max-width: 90em);
 
 ._media_queries_source__red {
   color: red;
 }
 
-@media (--small) {
+@media (max-width: 30em) {
   ._media_queries_source__red {
     color: maroon;
   }
 }
 
-@media (--medium) {
+@media (max-width: 60em) {
   ._media_queries_source__red {
     color: darkmagenta;
   }
 }
 
-@media (--large) {
+@media (max-width: 90em) {
   ._media_queries_source__red {
     color: fuchsia;
   }

--- a/test/test-cases/media-queries/expected.json
+++ b/test/test-cases/media-queries/expected.json
@@ -1,3 +1,6 @@
 {
-  "red": "_media-queries_source__red"
+  "red": "_media_queries_source__red",
+  "--small": "(max-width: 30em)",
+  "--medium": "(max-width: 60em)",
+  "--large": "(max-width: 90em)"
 }

--- a/test/test-cases/media-queries/expected.json
+++ b/test/test-cases/media-queries/expected.json
@@ -1,0 +1,3 @@
+{
+  "red": "_media-queries_source__red"
+}

--- a/test/test-cases/media-queries/source.css
+++ b/test/test-cases/media-queries/source.css
@@ -1,6 +1,6 @@
 @custom-media --small from "./breakpoints.css";
 @custom-media --medium from "./breakpoints.css";
-@custom-media --large from "./breakpoints.css";
+@custom-media --large (min-width: 90em);
 
 .red {
   color: red;

--- a/test/test-cases/media-queries/source.css
+++ b/test/test-cases/media-queries/source.css
@@ -1,0 +1,25 @@
+@custom-media --small from "./breakpoints.css";
+@custom-media --medium from "./breakpoints.css";
+@custom-media --large from "./breakpoints.css";
+
+.red {
+  color: red;
+}
+
+@media (--small) {
+  .red {
+    color: maroon;
+  }
+}
+
+@media (--medium) {
+  .red {
+    color: darkmagenta;
+  }
+}
+
+@media (--large) {
+  .red {
+    color: fuchsia;
+  }
+}

--- a/test/test-cases/media-queries/source.css
+++ b/test/test-cases/media-queries/source.css
@@ -1,6 +1,6 @@
 @custom-media --small from "./breakpoints.css";
 @custom-media --medium from "./breakpoints.css";
-@custom-media --large (min-width: 90em);
+@custom-media --large (max-width: 90em);
 
 .red {
   color: red;


### PR DESCRIPTION
About a month ago I was chatting with Mark & Josh about what's needed for a full 1.0 release of CSS Modules. I argued that we needed a first-class method for importing media queries, which I've been thinking about since and implemented over the last couple of weeks.

Here's my proposal:
- Build upon the `@custom-media` [spec](https://drafts.csswg.org/mediaqueries/#custom-mq)
- Build upon the [postcss-custom-media](https://github.com/postcss/postcss-custom-media) plugin
- All `@custom-media` statements are exported
- You import using `@custom-media --breakpoint from "./file.css"`

For example:

``` css
/* breakpoints.css */
@custom-media --small (max-width: 30em);
@custom-media --medium (max-width: 60em);
```

``` css
/* component.css */
@custom-media --small from "./breakpoints.css";
@custom-media --medium from "./breakpoints.css";

.red {
  color: red;
}

@media (--small) {
  .red {
    color: maroon;
  }
}

@media (--medium) {
  .red {
    color: darkmagenta;
  }
}
```

Now, in order for this to occur, I've had to add the postcss-custom-media plugin to run _after_ the import statements are linked but before the `injectableSource` is ready to hit the browser. That's because custom media needs a polyfill, which needs to run before the CSS is usable. So the `@custom-media` expressions **are processed & removed before they hit the browser**. That means they don't have to be localised like class names do.

_However_, I am not 100% sure about this design. `@custom-media` will eventually be available in the browsers, and so then we'd need to change behaviour to localise media expressions. There'd also not be any point in importing `@custom-media --breakpoint from "file.css", something like`@media (--breakpoint from "file.css")` would make much more sense. That syntax breaks Sass, which is why I haven't used it yet. But it's a thought.

An alternative is coming up with a totally general variable export/import syntax (probably building on [postcss-simple-vars](https://github.com/postcss/postcss-simple-vars)) that could be used for media queries as well.

``` css
$small: $breakpoint-small from "./breakpoints.css";
```

Anyway, wanted to open the discussion. I've pushed the postcss transforms used here to npm under the `beta` tag, so this build should be passing (travis is having weird problems with Node v0.10 and v0.12 today, but IO v3 is building fine).

I'd love to have this merged and v1 released by the time I present CSS Modules at React Rally on the 24th.
