### PR TITLE
Fix lint errors and enforced consistency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
 		"jsx": true
 	},
 	"rules": {
-		"quotes": "single"
+		"quotes": [2, "single"],
+		"space-in-parens": [2, "always"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint src",
     "build": "babel --out-dir lib src",
     "autotest": "chokidar src test -c 'npm test'",
-    "test": "mocha --compilers js:babel/register",
+    "test": "npm run lint && mocha --compilers js:babel/register",
     "prepublish": "npm run build"
   },
   "repository": {

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -1,6 +1,6 @@
-import Core from './index.js'
-import fs from 'fs'
-import path from 'path'
+import Core from './index.js';
+import fs from 'fs';
+import path from 'path';
 
 // Sorts dependencies in the following way:
 // AAA comes before AA and A
@@ -11,56 +11,58 @@ import path from 'path'
 // - After all their dependencies
 const traceKeySorter = ( a, b ) => {
   if ( a.length < b.length ) {
-    return a < b.substring( 0, a.length ) ? -1 : 1
+    return a < b.substring( 0, a.length ) ? -1 : 1;
   } else if ( a.length > b.length ) {
-    return a.substring( 0, b.length ) <= b ? -1 : 1
+    return a.substring( 0, b.length ) <= b ? -1 : 1;
   } else {
-    return a < b ? -1 : 1
+    return a < b ? -1 : 1;
   }
 };
 
 export default class FileSystemLoader {
   constructor( root, plugins ) {
-    this.root = root
-    this.sources = {}
-    this.importNr = 0
-    this.core = new Core(plugins)
+    this.root = root;
+    this.sources = {};
+    this.importNr = 0;
+    this.core = new Core( plugins );
     this.tokensByFile = {};
   }
 
   fetch( _newPath, relativeTo, _trace ) {
-    let newPath = _newPath.replace( /^["']|["']$/g, "" ),
-      trace = _trace || String.fromCharCode( this.importNr++ )
+    let newPath = _newPath.replace( /^["']|["']$/g, '' );
+    let trace = _trace || String.fromCharCode( this.importNr++ );
     return new Promise( ( resolve, reject ) => {
-      let relativeDir = path.dirname( relativeTo ),
-        rootRelativePath = path.resolve( relativeDir, newPath ),
-        fileRelativePath = path.resolve( path.join( this.root, relativeDir ), newPath )
+      let relativeDir = path.dirname( relativeTo );
+      let rootRelativePath = path.resolve( relativeDir, newPath );
+      let fileRelativePath = path.resolve( path.join( this.root, relativeDir ), newPath );
 
       // if the path is not relative or absolute, try to resolve it in node_modules
-      if (newPath[0] !== '.' && newPath[0] !== '/') {
+      if ( newPath[0] !== '.' && newPath[0] !== '/' ) {
         try {
-          fileRelativePath = require.resolve(newPath);
+          fileRelativePath = require.resolve( newPath );
         }
-        catch (e) {}
+        catch ( e ) {
+          console.error( e );
+        }
       }
 
-      const tokens = this.tokensByFile[fileRelativePath]
-      if (tokens) { return resolve(tokens) }
+      const tokens = this.tokensByFile[fileRelativePath];
+      if ( tokens ) { return resolve( tokens ); }
 
-      fs.readFile( fileRelativePath, "utf-8", ( err, source ) => {
-        if ( err ) reject( err )
+      fs.readFile( fileRelativePath, 'utf-8', ( err, source ) => {
+        if ( err ) { reject( err ); }
         this.core.load( source, rootRelativePath, trace, this.fetch.bind( this ) )
           .then( ( { injectableSource, exportTokens } ) => {
-            this.sources[trace] = injectableSource
-            this.tokensByFile[fileRelativePath] = exportTokens
-            resolve( exportTokens )
-          }, reject )
-      } )
-    } )
+            this.sources[trace] = injectableSource;
+            this.tokensByFile[fileRelativePath] = exportTokens;
+            resolve( exportTokens );
+          }, reject );
+      } );
+    } );
   }
 
   get finalSource() {
     return Object.keys( this.sources ).sort( traceKeySorter ).map( s => this.sources[s] )
-      .join( "" )
+      .join( '' );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,28 @@
-import postcss from 'postcss'
-import localByDefault from 'postcss-modules-local-by-default'
-import extractImports from 'postcss-modules-extract-imports'
-import scope from 'postcss-modules-scope'
+import postcss from 'postcss';
+import localByDefault from 'postcss-modules-local-by-default';
+import extractImports from 'postcss-modules-extract-imports';
+import scope from 'postcss-modules-scope';
 
-import Parser from './parser'
+import Parser from './parser';
 
 export default class Core {
   constructor( plugins ) {
-    this.plugins = plugins || Core.defaultPlugins
+    this.plugins = plugins || Core.defaultPlugins;
   }
 
   load( sourceString, sourcePath, trace, pathFetcher ) {
-    let parser = new Parser( pathFetcher, trace )
+    let parser = new Parser( pathFetcher, trace );
 
     return postcss( this.plugins.concat( [parser.plugin] ) )
-      .process( sourceString, { from: "/" + sourcePath } )
+      .process( sourceString, { from: '/' + sourcePath } )
       .then( result => {
-        return { injectableSource: result.css, exportTokens: parser.exportTokens }
-      } )
+        return { injectableSource: result.css, exportTokens: parser.exportTokens };
+      } );
   }
 }
 
-
 // These three plugins are aliased under this package for simplicity.
-Core.localByDefault = localByDefault
-Core.extractImports = extractImports
-Core.scope = scope
-Core.defaultPlugins = [localByDefault, extractImports, scope]
+Core.localByDefault = localByDefault;
+Core.extractImports = extractImports;
+Core.scope = scope;
+Core.defaultPlugins = [localByDefault, extractImports, scope];


### PR DESCRIPTION
There were nearly 100 lint errors, I have fixed them all. Furthermore, I have updated the `.lintrc` to properly enforce string quote and parenthesis consistency. I also made it so tests will fail if there are lint problems.

Personally, I'm a fan of `"space-in-parens": [2, "never"]`, but because the project uses spaces in parenthesis, `"space-in-parens": [2, "always"]` is now enforced. (_I'd be happy to switch everything to no spaces in parens if the maintainer wanted to_ :wink: )

I have a diff that addresses https://github.com/css-modules/css-modules-loader-core/issues/13 but I wanted to fix linting first in a separate PR.

I also have a feeling that eslint was actually misconfigured and semicolons are not desired... in which case I recommend adopting https://github.com/feross/standard. I'd be more than happy to reformat things.

We have plans to use `css-modules` in production so I'm definitely more than willing to assist setup tooling stuff and other chores (code coverage, etc.) to help improve quality across the board.
