### PR TITLE
Initial dead code elimination

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "lodash.partialright": "^3.1.1",
     "postcss": "^4.1.11",
     "postcss-modules-extract-imports": "^0.0.5",
     "postcss-modules-local-by-default": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "postcss": "^4.1.11",
     "postcss-modules-extract-imports": "^0.0.5",
     "postcss-modules-local-by-default": "^0.0.9",
-    "postcss-modules-scope": "^0.0.8"
+    "postcss-modules-scope": "^0.0.8",
+    "selector-has": "^1.0.0"
   },
   "devDependencies": {
     "babel": "^5.5.4",

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -1,8 +1,9 @@
 import Core from './index.js'
 import fs from 'fs'
 import path from 'path'
-import partialRight from 'lodash.partialright'
 import {parse} from 'postcss';
+import selectorHas from 'selector-has'
+import partialRight from 'lodash.partialright'
 
 // Sorts dependencies in the following way:
 // AAA comes before AA and A
@@ -66,7 +67,7 @@ export default class FileSystemLoader {
             if (exportedNames[name]) {
               name = exportedNames[name]
             }
-            return decl.selector === ':export' || containsClass(decl.selector, name)
+            return decl.selector === ':export' || selectorHas(decl.selector, name)
           })) {
             decl.removeSelf()
           }
@@ -89,9 +90,4 @@ export default class FileSystemLoader {
     return Object.keys( this.sources ).sort( traceKeySorter ).map( s => this.sources[s] )
       .join( "" )
   }
-}
-
-function containsClass(selector, className) {
-  let test = new RegExp('\\.' + className + '($|[\\s\.\[,>+~#:])');
-  return selector.match(test);
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -16,10 +16,12 @@ export default class Parser {
   }
 
   fetchAllImports( css ) {
+    let importedClasses = []
     let imports = []
     css.each( node => {
       if ( node.type == "rule" && node.selector.match( importRegexp ) ) {
-        imports.push( this.fetchImport( node, css.source.input.from, imports.length ) )
+        importedClasses = node.nodes.map(decl => decl.value);
+        imports.push( this.fetchImport( node, css.source.input.from, imports.length, importedClasses ) )
       }
     } )
     return imports
@@ -51,10 +53,11 @@ export default class Parser {
     exportNode.removeSelf()
   }
 
-  fetchImport( importNode, relativeTo, depNr ) {
+  fetchImport( importNode, relativeTo, depNr, stuff) {
     let file = importNode.selector.match( importRegexp )[1],
       depTrace = this.trace + String.fromCharCode(depNr)
-    return this.pathFetcher( file, relativeTo, depTrace ).then( exports => {
+
+    return this.pathFetcher( file, relativeTo, depTrace, stuff ).then( exports => {
       importNode.each( decl => {
         if ( decl.type == 'decl' ) {
           this.translations[decl.prop] = exports[decl.value]

--- a/src/parser.js
+++ b/src/parser.js
@@ -53,11 +53,11 @@ export default class Parser {
     exportNode.removeSelf()
   }
 
-  fetchImport( importNode, relativeTo, depNr, stuff) {
+  fetchImport( importNode, relativeTo, depNr, importedClasses ) {
     let file = importNode.selector.match( importRegexp )[1],
       depTrace = this.trace + String.fromCharCode(depNr)
 
-    return this.pathFetcher( file, relativeTo, depTrace, stuff ).then( exports => {
+    return this.pathFetcher( file, relativeTo, depTrace, importedClasses ).then( exports => {
       importNode.each( decl => {
         if ( decl.type == 'decl' ) {
           this.translations[decl.prop] = exports[decl.value]

--- a/test/test-cases/multiple-composes/c.css
+++ b/test/test-cases/multiple-composes/c.css
@@ -1,0 +1,14 @@
+.c1 {
+  composes: d1 from "./d.css";
+  color: #c1c1c1;
+}
+
+.c2 {
+  composes: d2 from "./d.css";
+  color: #c2c2c2;
+}
+
+.c3 {
+  composes: d3 from "./d.css";
+  color: #c3c3c3;
+}

--- a/test/test-cases/multiple-composes/d.css
+++ b/test/test-cases/multiple-composes/d.css
@@ -1,0 +1,15 @@
+.d1 {
+  color: #d1d1d1;
+}
+
+.d2 {
+  color: #d2d2d2;
+}
+
+.d3 {
+  color: #d3d3d3;
+}
+
+.d1 .another {
+  color: #555;
+}

--- a/test/test-cases/multiple-composes/expected.css
+++ b/test/test-cases/multiple-composes/expected.css
@@ -1,0 +1,25 @@
+._multiple_composes_d__d1 {
+  color: #d1d1d1;
+}
+
+._multiple_composes_d__d2 {
+  color: #d2d2d2;
+}
+
+._multiple_composes_d__d1 ._multiple_composes_d__another {
+  color: #555;
+}
+._multiple_composes_c__c1 {
+  color: #c1c1c1;
+}
+
+._multiple_composes_c__c2 {
+  color: #c2c2c2;
+}
+._multiple_composes_source__a {
+  color: #aaa;
+}
+
+._multiple_composes_source__b {
+  color: #bbb;
+}

--- a/test/test-cases/multiple-composes/expected.json
+++ b/test/test-cases/multiple-composes/expected.json
@@ -1,0 +1,4 @@
+{
+  "a": "_multiple_composes_source__a _multiple_composes_c__c1 _multiple_composes_d__d1",
+  "b": "_multiple_composes_source__b _multiple_composes_c__c2 _multiple_composes_d__d2"
+}

--- a/test/test-cases/multiple-composes/source.css
+++ b/test/test-cases/multiple-composes/source.css
@@ -1,0 +1,9 @@
+.a {
+  composes: c1 from "./c.css";
+  color: #aaa;
+}
+
+.b {
+  composes: c2 from "./c.css";
+  color: #bbb;
+}

--- a/test/test-cases/multiple-sources/b.css
+++ b/test/test-cases/multiple-sources/b.css
@@ -2,3 +2,11 @@
   composes: d from "./d.css";
   color: #bbb;
 }
+
+.b2 {
+  color: #b2b2b2;
+}
+
+.ab {
+  color: #ababab;
+}

--- a/test/test-cases/multiple-sources/expected.css
+++ b/test/test-cases/multiple-sources/expected.css
@@ -10,6 +10,9 @@
 ._multiple_sources_source1__a {
   color: #aaa;
 }
+._multiple_sources_b__b2 {
+  color: #b2b2b2;
+}
 ._multiple_sources_source2__foo {
   color: #f00;
 }

--- a/test/test-cases/multiple-sources/expected.json
+++ b/test/test-cases/multiple-sources/expected.json
@@ -1,4 +1,4 @@
 {
   "a": "_multiple_sources_source1__a _multiple_sources_b__b _multiple_sources_d__d _multiple_sources_c__c",
-  "foo": "_multiple_sources_source2__foo _multiple_sources_b__b _multiple_sources_d__d"
+  "foo": "_multiple_sources_source2__foo _multiple_sources_b__b2"
 }

--- a/test/test-cases/multiple-sources/source2.css
+++ b/test/test-cases/multiple-sources/source2.css
@@ -1,4 +1,4 @@
 .foo {
-  composes: b from "./b.css";
+  composes: b2 from "./b.css";
   color: #f00;
 }


### PR DESCRIPTION
Implemented dead code elimination and updated tests. Fixes https://github.com/css-modules/css-modules-loader-core/issues/13

I could be missing something in terms of the greater context including `css-modulesify`/`css-modules-require-hook` but for the sake of this repo, dead code elimination now works. It is also possible I'm doing something naive, but as far as I can tell everything works.

I basically removed the caching that was previously happening, I probably can trivially put back in some caching in the case of composing the same classes from the same file (but not in the case of different classes from the same file). We probably could also make dead code elimination a configuration option and thus optional if you're worried about compile performance (for example during hot loading).

I intend to clean up the tests a little bit and add some more tests (including comprehensive unit tests for the [`containsClass` function](https://github.com/css-modules/css-modules-loader-core/pull/20/files#diff-18684b7c7ee2ced4689cc61430d7c9c8R94)).

This PR contains lint/formatting problems which I intend to fix after https://github.com/css-modules/css-modules-loader-core/pull/19 is addressed.
