### PR TITLE
Updating the version of postcss-modules-local-by-default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "postcss": "^4.1.11",
     "postcss-modules-extract-imports": "^0.0.5",
-    "postcss-modules-local-by-default": "^0.0.9",
+    "postcss-modules-local-by-default": "^0.0.12",
     "postcss-modules-scope": "^0.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
There are a few bug fixes present in local-by-default > 0.0.9. Namely not blowing up on URLs when you don't pass options to it.
