### PR TITLE
Fix class naming, path resolution, and broken tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "icss-replace-symbols": "1.0.2",
+    "path-is-absolute": "^1.0.0",
     "postcss": "5.0.10",
     "postcss-modules-values": "1.1.1",
     "postcss-modules-extract-imports": "1.0.0",

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -1,6 +1,7 @@
 import Core from './index.js'
 import fs from 'fs'
 import path from 'path'
+import pathIsAbsolute from 'path-is-absolute';
 
 // Sorts dependencies in the following way:
 // AAA comes before AA and A
@@ -39,7 +40,7 @@ export default class FileSystemLoader {
       trace = _trace || String.fromCharCode( this.importNr++ )
     return new Promise( ( resolve, reject ) => {
       let relativeDir = path.dirname( relativeTo ),
-        fileRelativePath = path.resolve(path.isAbsolute(relativeDir) ? relativeDir : path.join( this.root, relativeDir ), newPath )
+        fileRelativePath = path.resolve(pathIsAbsolute(relativeDir) ? relativeDir : path.join( this.root, relativeDir ), newPath )
 
       // if the path is not relative or absolute, try to resolve it in node_modules
       if (newPath[0] !== '.' && newPath[0] !== '/') {

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -26,6 +26,12 @@ export default class FileSystemLoader {
     this.importNr = 0
     this.core = new Core(plugins)
     this.tokensByFile = {};
+
+    Core.scope.generateScopedName = function (exportedName, unsanitizedPath) {
+      let sanitizedPath = path.relative(root, unsanitizedPath).replace(/\.[^\.\/\\]+$/, '').replace(/[\W_]+/g, '_').replace(/^_|_$/g, '');
+      return `_${sanitizedPath}__${exportedName}`;
+    };
+
   }
 
   fetch( _newPath, relativeTo, _trace ) {
@@ -33,8 +39,7 @@ export default class FileSystemLoader {
       trace = _trace || String.fromCharCode( this.importNr++ )
     return new Promise( ( resolve, reject ) => {
       let relativeDir = path.dirname( relativeTo ),
-        rootRelativePath = path.resolve( relativeDir, newPath ),
-        fileRelativePath = path.resolve( path.join( this.root, relativeDir ), newPath )
+        fileRelativePath = path.resolve(path.isAbsolute(relativeDir) ? relativeDir : path.join( this.root, relativeDir ), newPath )
 
       // if the path is not relative or absolute, try to resolve it in node_modules
       if (newPath[0] !== '.' && newPath[0] !== '/') {
@@ -49,7 +54,7 @@ export default class FileSystemLoader {
 
       fs.readFile( fileRelativePath, "utf-8", ( err, source ) => {
         if ( err ) reject( err )
-        this.core.load( source, rootRelativePath, trace, this.fetch.bind( this ) )
+        this.core.load( source, fileRelativePath, trace, this.fetch.bind( this ) )
           .then( ( { injectableSource, exportTokens } ) => {
             this.sources[trace] = injectableSource
             this.tokensByFile[fileRelativePath] = exportTokens

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default class Core {
     let parser = new Parser( pathFetcher, trace )
 
     return postcss( this.plugins.concat( [parser.plugin] ) )
-      .process( sourceString, { from: "/" + sourcePath } )
+      .process( sourceString, { from: sourcePath } )
       .then( result => {
         return { injectableSource: result.css, exportTokens: parser.exportTokens }
       } )

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -23,8 +23,8 @@ Object.keys( pipelines ).forEach( dirname => {
           let expected = normalize( fs.readFileSync( path.join( testDir, testCase, "expected.css" ), "utf-8" ) )
           let loader = new FileSystemLoader( testDir, pipelines[dirname] )
           let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, "expected.json" ), "utf-8" ) )
-          loader.fetch( `${testCase}/source.css`, "/" ).then( tokens => {
-            assert.equal( loader.finalSource, expected )
+          loader.fetch( `${testCase}/source.css`, "./" ).then( tokens => {
+            assert.equal( normalize(loader.finalSource), expected )
             assert.equal( JSON.stringify( tokens ), JSON.stringify( expectedTokens ) )
           } ).then( done, done )
         } );
@@ -43,9 +43,9 @@ describe( 'multiple sources', () => {
       let expected = normalize( fs.readFileSync( path.join( testDir, testCase, "expected.css" ), "utf-8" ) )
       let loader = new FileSystemLoader( testDir, pipelines[dirname] )
       let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, "expected.json" ), "utf-8" ) )
-      loader.fetch( `${testCase}/source1.css`, "/" ).then( tokens1 => {
-        loader.fetch( `${testCase}/source2.css`, "/" ).then( tokens2 => {
-          assert.equal( loader.finalSource, expected )
+      loader.fetch( `${testCase}/source1.css`, "./" ).then( tokens1 => {
+        loader.fetch( `${testCase}/source2.css`, "./" ).then( tokens2 => {
+          assert.equal( normalize(loader.finalSource), expected )
           const tokens = Object.assign({}, tokens1, tokens2);
           assert.equal( JSON.stringify( tokens ), JSON.stringify( expectedTokens ) )
         } ).then( done, done )

--- a/test/test-cases/compose-node-module/expected.css
+++ b/test/test-cases/compose-node-module/expected.css
@@ -1,4 +1,4 @@
-._compose_node_module_cool_styles_foo__example {
+._node_modules_cool_styles_foo__example {
   color: #F00;
 }
 ._compose_node_module_source__foo {

--- a/test/test-cases/compose-node-module/expected.json
+++ b/test/test-cases/compose-node-module/expected.json
@@ -1,3 +1,3 @@
 {
-  "foo": "_compose_node_module_source__foo _compose_node_module_cool_styles_foo__example"
+  "foo": "_compose_node_module_source__foo _node_modules_cool_styles_foo__example"
 }


### PR DESCRIPTION
I put this together to resolve #16, and have tested it on Windows and Mac.

It requires a bit of a hack to the postcss-modules-scope plugin. PostCSS converts the "from" path to an absolute path, so I've adjusted the scope plugin's generateScopedName function to make the path (and hence class name) relative to the FileSystemLoader's root.
