### PR TITLE
more accurate way for resolving files in node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "dependencies": {
     "icss-replace-symbols": "1.0.2",
     "postcss": "5.0.10",
-    "postcss-modules-values": "1.1.1",
     "postcss-modules-extract-imports": "1.0.0",
     "postcss-modules-local-by-default": "1.0.1",
-    "postcss-modules-scope": "1.0.0"
+    "postcss-modules-scope": "1.0.0",
+    "postcss-modules-values": "1.1.1",
+    "resolve": "^1.1.7"
   },
   "devDependencies": {
     "babel": "5.8.29",

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -1,6 +1,7 @@
 import Core from './index.js'
 import fs from 'fs'
 import path from 'path'
+import nodeResolve from 'resolve'
 
 // Sorts dependencies in the following way:
 // AAA comes before AA and A
@@ -34,12 +35,13 @@ export default class FileSystemLoader {
     return new Promise( ( resolve, reject ) => {
       let relativeDir = path.dirname( relativeTo ),
         rootRelativePath = path.resolve( relativeDir, newPath ),
-        fileRelativePath = path.resolve( path.join( this.root, relativeDir ), newPath )
+        rootRelativeDir = path.join( this.root, relativeDir ),
+        fileRelativePath = path.resolve( rootRelativeDir, newPath )
 
       // if the path is not relative or absolute, try to resolve it in node_modules
       if (newPath[0] !== '.' && newPath[0] !== '/') {
         try {
-          fileRelativePath = require.resolve(newPath);
+          fileRelativePath = nodeResolve.sync(newPath, { basedir: rootRelativeDir });
         }
         catch (e) {}
       }

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -42,6 +42,8 @@ export default class FileSystemLoader {
       if (newPath[0] !== '.' && newPath[0] !== '/') {
         try {
           fileRelativePath = nodeResolve.sync(newPath, { basedir: rootRelativeDir });
+          // in this case we need to actualize rootRelativePath too
+          rootRelativePath = path.relative(this.root, fileRelativePath);
         }
         catch (e) {}
       }

--- a/test/test-cases/compose-local-node-module/expected.css
+++ b/test/test-cases/compose-local-node-module/expected.css
@@ -1,4 +1,4 @@
-._compose_local_node_module_cool_local_styles_foo__example {
+._compose_local_node_module_node_modules_cool_local_styles_foo__example {
   color: #F00;
 }
 ._compose_local_node_module_source__foo {

--- a/test/test-cases/compose-local-node-module/expected.css
+++ b/test/test-cases/compose-local-node-module/expected.css
@@ -1,0 +1,5 @@
+._compose_local_node_module_cool_local_styles_foo__example {
+  color: #F00;
+}
+._compose_local_node_module_source__foo {
+}

--- a/test/test-cases/compose-local-node-module/expected.json
+++ b/test/test-cases/compose-local-node-module/expected.json
@@ -1,0 +1,3 @@
+{
+  "foo": "_compose_local_node_module_source__foo _compose_local_node_module_cool_local_styles_foo__example"
+}

--- a/test/test-cases/compose-local-node-module/expected.json
+++ b/test/test-cases/compose-local-node-module/expected.json
@@ -1,3 +1,3 @@
 {
-  "foo": "_compose_local_node_module_source__foo _compose_local_node_module_cool_local_styles_foo__example"
+  "foo": "_compose_local_node_module_source__foo _compose_local_node_module_node_modules_cool_local_styles_foo__example"
 }

--- a/test/test-cases/compose-local-node-module/node_modules/cool-local-styles/foo.css
+++ b/test/test-cases/compose-local-node-module/node_modules/cool-local-styles/foo.css
@@ -1,0 +1,3 @@
+.example {
+  color: #F00;
+}

--- a/test/test-cases/compose-local-node-module/source.css
+++ b/test/test-cases/compose-local-node-module/source.css
@@ -1,0 +1,3 @@
+.foo {
+  composes: example from "cool-local-styles/foo.css";
+}

--- a/test/test-cases/compose-node-module/expected.css
+++ b/test/test-cases/compose-node-module/expected.css
@@ -1,4 +1,4 @@
-._compose_node_module_cool_styles_foo__example {
+._node_modules_cool_styles_foo__example {
   color: #F00;
 }
 ._compose_node_module_source__foo {

--- a/test/test-cases/compose-node-module/expected.json
+++ b/test/test-cases/compose-node-module/expected.json
@@ -1,3 +1,3 @@
 {
-  "foo": "_compose_node_module_source__foo _compose_node_module_cool_styles_foo__example"
+  "foo": "_compose_node_module_source__foo _node_modules_cool_styles_foo__example"
 }


### PR DESCRIPTION
require.resolve always try resolve file from place where it was called. But it's not correct behaviour. We need resolve from original css file.

substack's resolve package allows do it in right way.
