### PR TITLE
update to postcss v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "css-modules-loader-core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A loader-agnostic CSS Modules implementation, based on PostCSS",
   "main": "lib/index.js",
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "icss-replace-symbols": "1.0.2",
-    "postcss": "5.2.9",
-    "postcss-modules-values": "1.2.2",
-    "postcss-modules-extract-imports": "1.0.1",
-    "postcss-modules-local-by-default": "1.1.1",
-    "postcss-modules-scope": "1.0.2"
+    "icss-replace-symbols": "1.1.0",
+    "postcss": "6.0.1",
+    "postcss-modules-extract-imports": "1.1.0",
+    "postcss-modules-local-by-default": "1.2.0",
+    "postcss-modules-scope": "1.1.0",
+    "postcss-modules-values": "1.3.0"
   },
   "devDependencies": {
     "babel": "5.8.29",


### PR DESCRIPTION
preliminary step for [postcss-modules](https://github.com/css-modules/postcss-modules) and [postcss-modules-extract-imports@1.2.0](https://github.com/css-modules/postcss-modules-extract-imports/releases/tag/v1.2.0) update