### PR TITLE
Chore: Modernize Dependencies

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,14 @@
+{
+	"presets": [
+		[
+			"@babel/preset-env", {
+				"loose": true,
+				"modules": "commonjs",
+				"targets": {
+					"node": "6"
+				}
+			}
+		]
+	],
+	"plugins": ["add-module-exports"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,26 +1,28 @@
 {
-	"parser": "babel-eslint",
 	"env": {
 		"node": true
 	},
-	"ecmaFeatures": {
-		"arrowFunctions": true,
-		"blockBindings": true,
-		"classes": true,
-		"defaultParams": true,
-		"destructuring": true,
-		"forOf": true,
-		"modules": true,
-		"objectLiteralComputedProperties": true,
-		"objectLiteralShorthandMethods": true,
-		"objectLiteralShorthandProperties": true,
-		"spread": true,
-		"superInFunctions": true,
-		"templateStrings": true,
-		"unicodeCodePointEscapes": true,
-		"jsx": true
+	"parser": "babel-eslint",
+	"parserOptions": {
+		"ecmaFeatures": {
+			"arrowFunctions": true,
+			"blockBindings": true,
+			"classes": true,
+			"defaultParams": true,
+			"destructuring": true,
+			"forOf": true,
+			"modules": true,
+			"objectLiteralComputedProperties": true,
+			"objectLiteralShorthandMethods": true,
+			"objectLiteralShorthandProperties": true,
+			"spread": true,
+			"superInFunctions": true,
+			"templateStrings": true,
+			"unicodeCodePointEscapes": true,
+			"jsx": true
+		}
 	},
 	"rules": {
-		"quotes": "single"
+		"quotes": [2, "single"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
     "test": "test"
   },
   "dependencies": {
-    "icss-replace-symbols": "1.1.0",
-    "postcss": "6.0.1",
-    "postcss-modules-extract-imports": "1.1.0",
-    "postcss-modules-local-by-default": "1.2.0",
-    "postcss-modules-scope": "1.1.0",
-    "postcss-modules-values": "1.3.0"
+    "icss-replace-symbols": "^1.1.0",
+    "postcss": "^7.0.32",
+    "postcss-modules-extract-imports": "^2.0.0",
+    "postcss-modules-local-by-default": "^3.0.2",
+    "postcss-modules-scope": "^2.2.0",
+    "postcss-modules-values": "^3.0.0"
   },
   "devDependencies": {
-    "babel": "5.8.29",
-    "babel-eslint": "7.1.0",
-    "babelify": "7.3.0",
-    "chokidar-cli": "1.1.0",
-    "eslint": "3.10.1",
-    "mocha": "3.1.2"
+    "babel": "6.23.0",
+    "babel-eslint": "10.1.0",
+    "babelify": "10.0.0",
+    "chokidar-cli": "2.1.0",
+    "eslint": "7.3.0",
+    "mocha": "8.0.1"
   },
   "scripts": {
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mocha": "8.0.1"
   },
   "scripts": {
-    "lint": "eslint src",
+    "lint": "eslint src test",
     "build": "babel --out-dir lib src",
     "autotest": "chokidar src test -c 'npm test'",
     "test": "mocha -r @babel/register",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "postcss-modules-values": "^3.0.0"
   },
   "devDependencies": {
-    "babel": "6.23.0",
+    "@babel/cli": "7.10.3",
+    "@babel/core": "7.10.3",
+    "@babel/preset-env": "7.10.3",
+    "@babel/register": "7.10.3",
     "babel-eslint": "10.1.0",
-    "babelify": "10.0.0",
+    "babel-plugin-add-module-exports": "1.0.2",
     "chokidar-cli": "2.1.0",
     "eslint": "7.3.0",
     "mocha": "8.0.1"
@@ -26,7 +29,7 @@
     "lint": "eslint src",
     "build": "babel --out-dir lib src",
     "autotest": "chokidar src test -c 'npm test'",
-    "test": "mocha --compilers js:babel/register",
+    "test": "mocha -r @babel/register",
     "prepublishOnly": "rm -rf lib/* && npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "babel --out-dir lib src",
     "autotest": "chokidar src test -c 'npm test'",
     "test": "mocha --compilers js:babel/register",
-    "prepublish": "rm -rf lib/* && npm run build"
+    "prepublishOnly": "rm -rf lib/* && npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/file-system-loader.js
+++ b/src/file-system-loader.js
@@ -30,7 +30,7 @@ export default class FileSystemLoader {
   }
 
   fetch( _newPath, relativeTo, _trace ) {
-    let newPath = _newPath.replace( /^["']|["']$/g, "" ),
+    let newPath = _newPath.replace( /^["']|["']$/g, '' ),
       trace = _trace || String.fromCharCode( this.importNr++ )
     return new Promise( ( resolve, reject ) => {
       let relativeDir = path.dirname( relativeTo ),
@@ -48,7 +48,7 @@ export default class FileSystemLoader {
       const tokens = this.tokensByFile[fileRelativePath]
       if (tokens) { return resolve(tokens) }
 
-      fs.readFile( fileRelativePath, "utf-8", ( err, source ) => {
+      fs.readFile( fileRelativePath, 'utf-8', ( err, source ) => {
         if ( err ) reject( err )
         this.core.load( source, rootRelativePath, trace, this.fetch.bind( this ) )
           .then( ( { injectableSource, exportTokens } ) => {
@@ -72,6 +72,6 @@ export default class FileSystemLoader {
       written.add(filename)
 
       return sources[filename];
-    }).join( "" )
+    }).join( '' )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default class Core {
     let parser = new Parser( pathFetcher, trace )
 
     return postcss( this.plugins.concat( [parser.plugin] ) )
-      .process( sourceString, { from: "/" + sourcePath } )
+      .process( sourceString, { from: '/' + sourcePath } )
       .then( result => {
         return { injectableSource: result.css, exportTokens: parser.exportTokens }
       } )

--- a/src/parser.js
+++ b/src/parser.js
@@ -19,7 +19,7 @@ export default class Parser {
   fetchAllImports( css ) {
     let imports = []
     css.each( node => {
-      if ( node.type == "rule" && node.selector.match( importRegexp ) ) {
+      if ( node.type == 'rule' && node.selector.match( importRegexp ) ) {
         imports.push( this.fetchImport( node, css.source.input.from, imports.length ) )
       }
     } )
@@ -32,7 +32,7 @@ export default class Parser {
 
   extractExports( css ) {
     css.each( node => {
-      if ( node.type == "rule" && node.selector == ":export" ) this.handleExport( node )
+      if ( node.type == 'rule' && node.selector == ':export' ) this.handleExport( node )
     } )
   }
 

--- a/test/test-cases.js
+++ b/test/test-cases.js
@@ -1,29 +1,29 @@
-"use strict";
+'use strict';
 
-import assert from "assert"
-import fs from "fs"
-import path from "path"
-import FileSystemLoader from "../src/file-system-loader"
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import FileSystemLoader from '../src/file-system-loader'
 
 let normalize = ( str ) => {
-  return str.replace( /\r\n?/g, "\n" );
+  return str.replace( /\r\n?/g, '\n' );
 }
 
 const pipelines = {
-  "test-cases": undefined,
-  "cssi": []
+  'test-cases': undefined,
+  'cssi': []
 }
 
 Object.keys( pipelines ).forEach( dirname => {
   describe( dirname, () => {
     let testDir = path.join( __dirname, dirname )
     fs.readdirSync( testDir ).forEach( testCase => {
-      if ( fs.existsSync( path.join( testDir, testCase, "source.css" ) ) ) {
-        it( "should " + testCase.replace( /-/g, " " ), done => {
-          let expected = normalize( fs.readFileSync( path.join( testDir, testCase, "expected.css" ), "utf-8" ) )
+      if ( fs.existsSync( path.join( testDir, testCase, 'source.css' ) ) ) {
+        it( 'should ' + testCase.replace( /-/g, ' ' ), done => {
+          let expected = normalize( fs.readFileSync( path.join( testDir, testCase, 'expected.css' ), 'utf-8' ) )
           let loader = new FileSystemLoader( testDir, pipelines[dirname] )
-          let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, "expected.json" ), "utf-8" ) )
-          loader.fetch( `${testCase}/source.css`, "/" ).then( tokens => {
+          let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, 'expected.json' ), 'utf-8' ) )
+          loader.fetch( `${testCase}/source.css`, '/' ).then( tokens => {
             assert.equal( loader.finalSource, expected )
             assert.equal( JSON.stringify( tokens ), JSON.stringify( expectedTokens ) )
           } ).then( done, done )
@@ -38,13 +38,13 @@ describe( 'multiple sources', () => {
   let testDir = path.join( __dirname, 'test-cases' )
   let testCase = 'multiple-sources';
   let dirname = 'test-cases';
-  if ( fs.existsSync( path.join( testDir, testCase, "source1.css" ) ) ) {
-    it( "should " + testCase.replace( /-/g, " " ), done => {
-      let expected = normalize( fs.readFileSync( path.join( testDir, testCase, "expected.css" ), "utf-8" ) )
+  if ( fs.existsSync( path.join( testDir, testCase, 'source1.css' ) ) ) {
+    it( 'should ' + testCase.replace( /-/g, ' ' ), done => {
+      let expected = normalize( fs.readFileSync( path.join( testDir, testCase, 'expected.css' ), 'utf-8' ) )
       let loader = new FileSystemLoader( testDir, pipelines[dirname] )
-      let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, "expected.json" ), "utf-8" ) )
-      loader.fetch( `${testCase}/source1.css`, "/" ).then( tokens1 => {
-        loader.fetch( `${testCase}/source2.css`, "/" ).then( tokens2 => {
+      let expectedTokens = JSON.parse( fs.readFileSync( path.join( testDir, testCase, 'expected.json' ), 'utf-8' ) )
+      loader.fetch( `${testCase}/source1.css`, '/' ).then( tokens1 => {
+        loader.fetch( `${testCase}/source2.css`, '/' ).then( tokens2 => {
           assert.equal( loader.finalSource, expected )
           const tokens = Object.assign({}, tokens1, tokens2);
           assert.equal( JSON.stringify( tokens ), JSON.stringify( expectedTokens ) )

--- a/test/test-cases/values/expected.css
+++ b/test/test-cases/values/expected.css
@@ -1,7 +1,7 @@
+
 ._values_borders__dashed {
   border: 4px dashed;
 }
-
 ._values_colors__text-primary {
   color: #f01;
 }


### PR DESCRIPTION
This package is seriously outdated, and it's causing a noticeable hiccup when installing `postcss-modules`. Analysis below:

> This module – **on its own** – pulls in two distinct versions of `postcss`: [graph](https://npm.anvaka.com/#!/view/2d/css-modules-loader-core)
>
> It's directly & solely responsible for `postcss@6.0.1` being loaded.
> It shares responsibility for `postcss@6.0.23` with:
> * `postcss-modules-scope@1.1.0` – (2.2.0 available)
> * `postcss-modules-local-by-default@1.2.0` – (3.0.2 available)
> * `postcss-modules-values@1.3.0` – (3.0.0 available)
> * `postcss-modules-extract-imports@1.1.0` – (2.0.0 available)
> 
> Then `postcss-modules`, a popular dependent of this package, requires `postcss@7.0.32` – as it should, since that's the latest. 
> 
> In any event `postcss-modules` loads [49 packages total](https://npm.anvaka.com/#!/view/2d/postcss-modules) in its network. This `css-modules-loader-core` package is responsible for **38 of them**.

This PR updates all dependencies to their **latest semver ranges**.
It also updates your devDependencies which were seriously outdated too.

It's actually pretty impressive that despite 5 dependencies loading new major versions, the only difference was with newline placements in the most complex test case. 👏 

---

Closes #231, #234, #233, #24